### PR TITLE
Prevent user event propagation from GUI to 3D

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,9 +58,7 @@ impl epi::App for Application {
     /// Called each time the UI needs repainting, which may be many times per second.
     /// Put your widgets into a `SidePanel`, `TopPanel`, `CentralPanel`, `Window` or `Area`.
     fn update(&mut self, ctx: &egui::CtxRef, _frame: &mut epi::Frame<'_>) {
-        egui::CentralPanel::default()
-            .frame(Frame::dark_canvas(&ctx.style()))
-            .show(ctx, |ui| self.ui(ui));
+        egui::Area::new("settings").show(ctx, |ui| self.ui(ui));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,7 @@ fn main() -> Result<()> {
 
     event_loop.run(move |event: Event<'_, ()>, _, control_flow| {
         state.platform.handle_event(&event);
-        if captures_event(&state.platform, &event) {
-            info!("captured");
-        }
+
         match event {
             Event::RedrawRequested(_) => {
                 let now = std::time::Instant::now();
@@ -100,18 +98,15 @@ fn main() -> Result<()> {
             Event::MainEventsCleared => {
                 window.request_redraw();
             }
-            Event::DeviceEvent {
-                ref event,
-                .. // We're not using device_id currently
-            } => {
-                state.input(event);
+            Event::DeviceEvent { .. } => {
+                state.input(&event);
             }
             Event::WindowEvent {
-                ref event,
+                event: ref window_event,
                 window_id,
                 ..
             } if window_id == window.id() => {
-                match event {
+                match window_event {
                     WindowEvent::CloseRequested => {
                         *control_flow = ControlFlow::Exit;
                     }
@@ -123,6 +118,10 @@ fn main() -> Result<()> {
                     }
 
                     _ => {}
+                }
+
+                if !state.platform.captures_event(&event) {
+                    state.input(&event);
                 }
             }
             _ => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,6 @@ struct Opt {
 fn main() -> Result<()> {
     use std::time::Instant;
 
-    use log::info;
-
     let opt = Opt::from_args();
 
     pretty_env_logger::formatted_builder()


### PR DESCRIPTION
Hi There!

I think this is my first pr in Rust so please let me know if anything should be done differently :)

This prevents the mouse/keyboard events to be caught by the 3d camera if egui wants to handle them.

Changes:
 - use `egui::Area` instead of `egui::CentralPanel` as the main container so the GUI won't cover the whole window
    - with this, we can see if the mouse is over the GUI or not
 - use `WindowEvent` instead of `DeviceEvent` for initiating interaction with the camera
    - we can't tell if DeviceEvents are handled by egui because egui_winit_platform forwards only `WindowEvent`s 
    - mouse-move/btn-relese events are still handled as DeviceEvents. So if the camera is grabbed, the interactions (move/release) will be handled even if the pointer leaves the window or goes over the GUI
    - also prevents moving the camera when the window is not focused
