### PR TITLE
Grab camera with mouse click and remove DeviceEvent related code

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -134,15 +134,21 @@ impl CameraController {
             }
             VirtualKeyCode::Escape => {
                 if is_pressed {
-                    self.mouse_captured = !self.mouse_captured;
-                    let _ = window.set_cursor_grab(self.mouse_captured);
-                    window.set_cursor_visible(!self.mouse_captured);
+                    self.set_mouse_captured(!self.mouse_captured, window);
                 }
 
                 true
             }
             _ => false,
         }
+    }
+
+    pub fn set_mouse_captured(&mut self, is_captured: bool, window: &Window) {
+        self.mouse_captured = is_captured;
+        self.rotate_horizontal = 0.0;
+        self.rotate_vertical = 0.0;
+        let _ = window.set_cursor_grab(is_captured);
+        window.set_cursor_visible(!is_captured);
     }
 
     pub fn process_mouse(&mut self, mouse_dx: f64, mouse_dy: f64) {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -90,7 +90,8 @@ impl Interface {
                     state,
                     ..
                 } => {
-                    self.camera_controller.mouse_captured = state == &ElementState::Pressed;
+                    self.camera_controller
+                        .set_mouse_captured(state == &ElementState::Pressed, window);
                     true
                 }
                 WindowEvent::CursorMoved { position, .. } => {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use egui::{Button, CollapsingHeader, Frame, Slider, Stroke, Ui};
 use winit::{
     dpi::PhysicalPosition,
-    event::{Event, KeyboardInput, WindowEvent},
+    event::{ElementState, Event, KeyboardInput, WindowEvent},
     window::Window,
 };
 
@@ -71,7 +71,6 @@ impl Interface {
 
     pub fn input(&mut self, event: &Event<'_, ()>, window: &Window) -> bool {
         match event {
-            // capture mouse-move and btn-release as `DeviceEvent`s so we can see them when the pointer leaves the screen
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::KeyboardInput {
                     input:
@@ -84,6 +83,14 @@ impl Interface {
                 } => self.camera_controller.process_keyboard(key, *state, window),
                 WindowEvent::MouseWheel { delta, .. } => {
                     self.camera_controller.process_scroll(delta);
+                    true
+                }
+                WindowEvent::MouseInput {
+                    button: winit::event::MouseButton::Left,
+                    state,
+                    ..
+                } => {
+                    self.camera_controller.mouse_captured = state == &ElementState::Pressed;
                     true
                 }
                 WindowEvent::CursorMoved { position, .. } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,9 +116,6 @@ fn main() -> Result<()> {
             Event::MainEventsCleared => {
                 window.request_redraw();
             }
-            Event::DeviceEvent { .. } => {
-                app.input(&event, &window);
-            }
             Event::WindowEvent {
                 event: ref window_event,
                 window_id,


### PR DESCRIPTION
I think the grab/release event handling was removed by mistake, so I added back. Let me know if I missed something. 
Also removed the DeviceEvent related lines since they are not used anymore. Nice solution fixing the mouse while moving the camera @Schweeble :clap: 